### PR TITLE
Enhance folder handling and add support for multibranch pipeline views

### DIFF
--- a/JenkinsiOS/Controller/SearchResultsTableViewController.swift
+++ b/JenkinsiOS/Controller/SearchResultsTableViewController.swift
@@ -26,7 +26,14 @@ class SearchResultsTableViewController: UITableViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        automaticallyAdjustsScrollViewInsets = false
+        edgesForExtendedLayout = []
+    }
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }

--- a/JenkinsiOS/Model/JenkinsAPI/Job/Job.swift
+++ b/JenkinsiOS/Model/JenkinsAPI/Job/Job.swift
@@ -70,7 +70,9 @@ class Job: Favoratible{
     ///
     /// - returns: The initialized Job object or nil, if initialization failed
     init?(json: [String: AnyObject], minimalVersion: Bool = false){
-        guard let name = json[Constants.JSON.name] as? String, let urlString = json[Constants.JSON.url] as? String
+        guard let nameUrlString = json[Constants.JSON.name] as? String,
+            let name = nameUrlString.removingPercentEncoding,
+            let urlString = json[Constants.JSON.url] as? String
             else { return nil }
         guard let url = URL(string: urlString)
             else { return nil }

--- a/JenkinsiOS/Model/JenkinsAPI/Job/JobList.swift
+++ b/JenkinsiOS/Model/JenkinsAPI/Job/JobList.swift
@@ -23,6 +23,8 @@ class JobList{
     var mode: String?
     /// The node's name
     var nodeName: String?
+    /// Whether this is a multibranch pipeline job list
+    var isMultibranch: Bool = false
     
     /// Initialize a JobList object
     ///
@@ -47,6 +49,15 @@ class JobList{
         nodeDescription = json[Constants.JSON.nodeDescription] as? String
         mode = json[Constants.JSON.mode] as? String
         nodeName = json[Constants.JSON.nodeName] as? String
-        
+
+        if let _class = json["_class"] as? String,
+            let jobType = JobListType(rawValue: _class),
+            jobType == .multibranch { isMultibranch = true }
     }
+}
+
+private enum JobListType: String {
+    case folder = "com.cloudbees.hudson.plugins.folder.Folder"
+    case list = "hudson.model.Hudson"
+    case multibranch = "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject"
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,10 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    scan(scheme: "JenkinsiOSTests")
+    scan(
+        scheme: "JenkinsiOSTests",
+        device: "iPhone SE"
+    )
   end
 
   desc "This will also make sure the profile is up to date"


### PR DESCRIPTION
I've been working with pipelines at work, and noticed some missing functionality in the app. When viewing a multibranch pipeline job, there was no picker to switch between the branch and pull request views. I updated the code to show the picker whenever there's more than 1 view.

I also updated the search bar to work for folders and multibranch pipeline jobs. There was an existing UI bug in the search results table view where the table was shifted downward. I fixed that issue as part of this patch.

I also changed the behavior of the picker view to feel a bit more intuitive. The current behavior is to always reset to the first picker element on refresh. I changed the behavior to only scroll to the first element on initial load, and otherwise stay on the same element that was selected between refreshes.

For multibranch pipeline jobs, I added some logic to display "Branches" and "Pull Requests" instead of "change-requests" and "default". This relies on the `_class` json member to determine if a job is a multibranch pipeline job. I'm not a huge fan of it, but it would fail gracefully enough if the value was changed, because it would just display the defaults.

Let me know if you'd like me to make any changes. Thanks!

/cc @mobi-robert 