### PR TITLE
JENIOS-50 Fix issue where parameters might not be parsed on some Jenkins instances

### DIFF
--- a/JenkinsiOS/Model/JenkinsAPI/Job/Job.swift
+++ b/JenkinsiOS/Model/JenkinsAPI/Job/Job.swift
@@ -131,17 +131,26 @@ class Job: Favoratible{
 
         // Parse all the parameters
         parameters = []
+        // For some reason there are multiple places in which the parameters may be defined. We
+        // will a
+        let possibleParameterDefinitionPlaces = [Constants.JSON.property, Constants.JSON.actions]
+        
+        for possibleParameterDefinitionPlace in possibleParameterDefinitionPlaces {
+            if let properties = json[possibleParameterDefinitionPlace] as? [[String: Any]],
+                let parametersJson = properties.first?[Constants.JSON.parameterDefinitions] as? [[String: Any]]{
+                
+                for parameterJson in parametersJson{
+                    guard let parameter = Parameter(json: parameterJson)
+                        else { continue }
 
-        if let properties = json[Constants.JSON.property] as? [[String: Any]], let parametersJson = properties.first?[Constants.JSON.parameterDefinitions] as? [[String: Any]]{
-            for parameterJson in parametersJson{
-                guard let parameter = Parameter(json: parameterJson)
-                    else { continue }
+                    if parameter.type == .run{
+                        parameter.additionalData = builds.map({ "\(name)#\($0.number)" }) as AnyObject?
+                    }
 
-                if parameter.type == .run{
-                    parameter.additionalData = builds.map({ "\(name)#\($0.number)" }) as AnyObject?
+                    parameters.append(parameter)
                 }
-
-                parameters.append(parameter)
+                
+                break;
             }
         }
 


### PR DESCRIPTION
This pull request fixes the following issues:
- On some Jenkins instances the parameter definitions for a given job are only available via the "actions" key and not the "property" key. This is now accounted for in the application (even though "property" is still given preferential treatment).