### PR TITLE
JENIOS-81 Fix issue with popping controller in onboarding flow

### DIFF
--- a/JenkinsiOS/Controller/AccountCreatedViewController.swift
+++ b/JenkinsiOS/Controller/AccountCreatedViewController.swift
@@ -22,6 +22,10 @@ class AccountCreatedViewController: UIViewController {
         view.backgroundColor = Constants.UI.backgroundColor
         doneButton.setTitle("DONE", for: .normal)
         doneButton.addTarget(self, action: #selector(doneButtonPressed), for: .touchUpInside)
+
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        navigationController?.isNavigationBarHidden = true
+        navigationItem.hidesBackButton = true
     }
 
     @objc private func doneButtonPressed() {


### PR DESCRIPTION
This pull request fixes the following issue:
- after creating a new account during the onboarding sequence, it was possible to navigate back to the account creation screen by popping the view controller
- This is now no longer possible