### PR TITLE
Update actions screen text and layout on older devices

### DIFF
--- a/JenkinsiOS/Controller/BuildQueueTableViewController.swift
+++ b/JenkinsiOS/Controller/BuildQueueTableViewController.swift
@@ -34,6 +34,8 @@ class BuildQueueTableViewController: RefreshingTableViewController, AccountProvi
         emptyTableView(for: .loading)
 
         contentType = .buildQueue
+
+        setBottomContentInsetForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/JenkinsiOS/Controller/ComputersTableViewController.swift
+++ b/JenkinsiOS/Controller/ComputersTableViewController.swift
@@ -31,6 +31,8 @@ class ComputersTableViewController: RefreshingTableViewController, AccountProvid
         emptyTableView(for: .loading)
 
         contentType = .nodes
+
+        setBottomContentInsetForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/JenkinsiOS/Controller/JenkinsInformationTableViewController.swift
+++ b/JenkinsiOS/Controller/JenkinsInformationTableViewController.swift
@@ -16,6 +16,8 @@ class JenkinsInformationTableViewController: UITableViewController, AccountProvi
         super.viewDidLoad()
         tableView.backgroundColor = Constants.UI.backgroundColor
         tableView.separatorStyle = .none
+
+        setBottomContentInsetForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/JenkinsiOS/Controller/JobsTableViewController.swift
+++ b/JenkinsiOS/Controller/JobsTableViewController.swift
@@ -97,6 +97,8 @@ class JobsTableViewController: RefreshingTableViewController, AccountProvidable 
         tableView.backgroundColor = Constants.UI.backgroundColor
 
         NotificationCenter.default.addObserver(self, selector: #selector(reloadFavorites), name: Constants.Identifiers.favoriteStatusToggledNotification, object: nil)
+
+        setBottomContentInsetForOlderDevices()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/JenkinsiOS/Other/Base.lproj/Main.storyboard
+++ b/JenkinsiOS/Other/Base.lproj/Main.storyboard
@@ -554,7 +554,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5yQ-3V-yER">
-                                                    <rect key="frame" x="8" y="4" width="304" height="67.5"/>
+                                                    <rect key="frame" x="8" y="4" width="304" height="68"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cez-co-vSL">
                                                             <rect key="frame" x="0.0" y="0.0" width="48" height="68"/>
@@ -564,7 +564,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hD5-7X-6bG">
-                                                            <rect key="frame" x="48" y="0.0" width="1" height="67.5"/>
+                                                            <rect key="frame" x="48" y="0.0" width="1" height="68"/>
                                                             <color key="backgroundColor" red="0.8862745098" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="1" id="skn-be-JzJ"/>

--- a/JenkinsiOS/Other/Extensions.swift
+++ b/JenkinsiOS/Other/Extensions.swift
@@ -209,6 +209,16 @@ extension UIViewController {
     }
 }
 
+extension UITableViewController {
+    /// Update the bottom content inset for devices that do not have safe area insets
+    func setBottomContentInsetForOlderDevices() {
+        if #available(iOS 11.0, *) {}
+        else {
+            tableView.contentInset.bottom = tabBarController?.tabBar.frame.height ?? tableView.contentInset.bottom
+        }
+    }
+}
+
 extension UIImageView {
     /// Set an image view's image to an image, resized by a scale factor
     ///

--- a/JenkinsiOS/View/ActionTableViewCell.swift
+++ b/JenkinsiOS/View/ActionTableViewCell.swift
@@ -61,7 +61,7 @@ private extension JenkinsAction {
         case .safeExit:
             return "Safe Exit"
         case .safeRestart:
-            return "Safe Exit"
+            return "Safe Restart"
         }
     }
 }

--- a/JenkinsiOS/View/SettingsTableViewController.swift
+++ b/JenkinsiOS/View/SettingsTableViewController.swift
@@ -58,6 +58,8 @@ class SettingsTableViewController: UITableViewController, AccountProvidable, Cur
         tabBarController?.navigationItem.title = "Settings"
         tableView.backgroundColor = Constants.UI.backgroundColor
         tableView.separatorStyle = .none
+
+        setBottomContentInsetForOlderDevices()
     }
 
     // MARK: - Table view data source


### PR DESCRIPTION
This pull request implements the following:
- Instead of "Safe Exit", the safe restart action is now correctly called "Safe Restart"
- On pre-iOS 11 devices, the tab bar now does not obstruct view on the last table view cells