### PR TITLE
Disallow selecting unbuilt build queue items

### DIFF
--- a/JenkinsiOS/Controller/BuildQueueTableViewController.swift
+++ b/JenkinsiOS/Controller/BuildQueueTableViewController.swift
@@ -118,6 +118,10 @@ class BuildQueueTableViewController: RefreshingTableViewController, AccountProvi
         performSegue(withIdentifier: Constants.Identifiers.showJobSegue, sender: queue?.items[indexPath.row])
     }
 
+    override func tableView(_: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return (queue?.items[indexPath.row].task?.wasBuilt ?? false) ? indexPath : nil
+    }
+
     // MARK: - View controller navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation

--- a/JenkinsiOS/Model/JenkinsAPI/Job/Job.swift
+++ b/JenkinsiOS/Model/JenkinsAPI/Job/Job.swift
@@ -65,6 +65,11 @@ class Job: Favoratible {
     /// The job's build parameters, if any
     var parameters: [Parameter] = []
 
+    /// Whether or not the job was previously built
+    var wasBuilt: Bool {
+        return color != .notBuilt
+    }
+
     /// Optionally initialize a Job
     ///
     /// - parameter json:           The json from which to initialize the job

--- a/JenkinsiOS/View/BuildQueueTableViewCell.swift
+++ b/JenkinsiOS/View/BuildQueueTableViewCell.swift
@@ -29,6 +29,8 @@ class BuildQueueTableViewCell: JobTableViewCell {
         super.setup(with: .job(job: task))
         causeLabel.text = queueItem.why
 
+        arrowView.isHidden = self.queueItem?.task?.wasBuilt == false
+
         // Extend the top color of the status view's image to fill the cell's height
         if let image = statusView.image, let cropped = image.cgImage?.cropping(to: CGRect(x: 0, y: 0, width: image.size.width / 4, height: image.size.height / 4)) {
             let patternImage = UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)


### PR DESCRIPTION
This pull request implements the following:
- Disallow navigating to jobs screens from build queue items that were unbuilt (there is nothing to see there anyways in those cases)